### PR TITLE
FIX #93 プレビューをサーバーサイドで行う

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -1,3 +1,2 @@
-window.$ = require('jquery')
-window.jQuery = $
+window.$ = window.jQuery = require('jquery')
 window.PoemForm = require('./components/PoemForm').default

--- a/app/assets/javascripts/components/PoemForm.jsx
+++ b/app/assets/javascripts/components/PoemForm.jsx
@@ -1,3 +1,4 @@
+const _ = require('underscore')
 export default class PoemForm extends React.Component {
   constructor(props) {
     super(props);
@@ -6,6 +7,10 @@ export default class PoemForm extends React.Component {
       description: props.description,
       description_html: props.description_html
     };
+    // reactではevent objectが毎回clearされるので
+    // constructorでdebounce化させておく必要があるらしい
+    // http://stackoverflow.com/questions/23123138/perform-debounce-in-react-js/24679479#24679479
+    this.createPreview = _.debounce(this.createPreview, 500);
   }
 
   componentDidMount(){
@@ -52,7 +57,7 @@ export default class PoemForm extends React.Component {
 
   onDescriptionChange(event) {
     this.setState({ description: event.target.value })
-    setTimeout( ()=>{ this.createPreview() }, 1000 )
+    this.createPreview()
   }
 
   rawMarkup() {

--- a/app/assets/javascripts/components/PoemForm.jsx
+++ b/app/assets/javascripts/components/PoemForm.jsx
@@ -10,7 +10,7 @@ export default class PoemForm extends React.Component {
     // reactではevent objectが毎回clearされるので
     // constructorでdebounce化させておく必要があるらしい
     // http://stackoverflow.com/questions/23123138/perform-debounce-in-react-js/24679479#24679479
-    this.createPreview = _.debounce(this.createPreview, 500);
+    this.createPreview = _.debounce(this.createPreview, 300);
   }
 
   componentDidMount(){

--- a/app/assets/javascripts/components/PoemForm.jsx
+++ b/app/assets/javascripts/components/PoemForm.jsx
@@ -1,13 +1,11 @@
-import md from 'markdown-it'
-import mdEmoji from 'markdown-it-emoji'
-import mdCheckBox from 'markdown-it-checkbox'
-const markdown_extension = { linkify: true, breaks: true }
-const markdown = md(markdown_extension).use(mdEmoji).use(mdCheckBox)
-
 export default class PoemForm extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {description: props.description, title: props.title};
+    this.state = {
+      title: props.title,
+      description: props.description,
+      description_html: props.description_html
+    };
   }
 
   componentDidMount(){
@@ -39,16 +37,36 @@ export default class PoemForm extends React.Component {
         }
       }
     })
+    .on({
+      // 候補から選択してもonChangeイベントが発火しないので、
+      // 強制的にonChangeさせる
+      'textComplete:select': (e, value, strategy) => {
+        this.onDescriptionChange(e)
+      }
+    })
   }
 
-  onChange(event) {
-    let attr = {}
-    attr[event.target.id] = event.target.value
-    this.setState(attr)
+  onTitleChange(event) {
+    this.setState({ title: event.target.value })
+  }
+
+  onDescriptionChange(event) {
+    this.setState({ description: event.target.value })
+    setTimeout( ()=>{ this.createPreview() }, 1000 )
   }
 
   rawMarkup() {
-    return { __html: markdown.render(this.state.description) };
+    return { __html: this.state.description_html };
+  }
+
+  createPreview() {
+    $.post(
+      '/api/markdown_previews',
+      { text: this.state.description },
+      'html'
+    ).done( (data) => {
+      this.setState({ description_html: data })
+    })
   }
 
   render () {
@@ -59,14 +77,14 @@ export default class PoemForm extends React.Component {
             <div className="form-group string required poem_title">
               <label className="string required control-label" htmlFor="poem_title">
                 <abbr title="required">*</abbr> タイトル</label>
-              <input className="string required form-control" onChange={this.onChange.bind(this)}
+              <input className="string required form-control" onChange={this.onTitleChange.bind(this)}
                 id="title" type="text" name="poem[title]" value={this.state.title}/>
             </div>
             <div className="form-group text required poem_description">
               <label className="text required control-label" htmlFor="poem_description">
                 <abbr title="required">*</abbr> 本文</label>
               <textarea className="text required form-control"
-                rows="10" onChange={this.onChange.bind(this)}
+                rows="10" onChange={this.onDescriptionChange.bind(this)}
                 id="description" name="poem[description]"
                 value={this.state.description} ref="textarea"></textarea>
             </div>
@@ -87,5 +105,6 @@ export default class PoemForm extends React.Component {
 
 PoemForm.propTypes = {
   title: React.PropTypes.string,
-  description: React.PropTypes.string
+  description: React.PropTypes.string,
+  description_html: React.PropTypes.string
 };

--- a/app/assets/javascripts/components/PoemForm.jsx
+++ b/app/assets/javascripts/components/PoemForm.jsx
@@ -35,13 +35,7 @@ export default class PoemForm extends React.Component {
         },
         index: 1
       }
-    ], {
-      onKeydown(e, commands) {
-        if (e.ctrlKey && e.keyCode === 74) { // CTRL-J
-          return commands.KEY_ENTER;
-        }
-      }
-    })
+    ])
     .on({
       // 候補から選択してもonChangeイベントが発火しないので、
       // 強制的にonChangeさせる

--- a/app/controllers/api/markdown_previews_controller.rb
+++ b/app/controllers/api/markdown_previews_controller.rb
@@ -1,0 +1,12 @@
+# NasuLog Api
+module Api
+  # return markdown preview
+  class MarkdownPreviewsController < ApplicationController
+    before_action :login_required
+    protect_from_forgery except: :create
+
+    def create
+      render html: view_context.markdown(params[:text]).html_safe
+    end
+  end
+end

--- a/app/controllers/api/markdown_previews_controller.rb
+++ b/app/controllers/api/markdown_previews_controller.rb
@@ -6,7 +6,7 @@ module Api
     protect_from_forgery except: :create
 
     def create
-      render html: view_context.markdown(params[:text]).html_safe
+      render html: view_context.markdown(params[:text])
     end
   end
 end

--- a/app/helpers/poem_helper.rb
+++ b/app/helpers/poem_helper.rb
@@ -20,7 +20,7 @@ module PoemHelper
   end
 
   def emojify(content)
-    return unless content.present?
+    return "" unless content.present?
 
     h(content).to_str.gsub(/:([\w+-]+):/) do |match|
       emoji_alias = Regexp.last_match(1)

--- a/app/views/poems/_form.html.erb
+++ b/app/views/poems/_form.html.erb
@@ -1,6 +1,10 @@
 <%= render partial: 'shared_partials/errors', object: poem.errors %>
 <%= simple_form_for poem do |f| %>
-  <%= react_component 'PoemForm', { title: poem.title.to_s, description: poem.description.to_s } %>
+  <%= react_component 'PoemForm', {
+    title: poem.title.to_s,
+    description: poem.description.to_s,
+    description_html: markdown(poem.description)
+  } %>
   <%= f.button :submit, class: "btn btn-primary" %>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,6 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :emoji, only: [:index]
+    resources :markdown_previews, only: [:create]
   end
 end

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "jquery-textcomplete": "^0.8.1",
     "markdown-it": "^5.1.0",
     "markdown-it-checkbox": "^1.1.0",
-    "markdown-it-emoji": "^1.1.0"
+    "markdown-it-emoji": "^1.1.0",
+    "underscore": "^1.8.3"
   }
 }

--- a/spec/controllers/api/markdown_previews_controller_spec.rb
+++ b/spec/controllers/api/markdown_previews_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Api::MarkdownPreviewsController, type: :controller do
+  describe 'Post #create', login_as: :current_user do
+    let(:current_user) { create(:user) }
+    let(:text) { 'hogehoge :octocat:' }
+    subject { post :create, text: text, format: :json }
+    it 'octocatのimage_pathがrenderされてかえること' do
+      is_expected.to be_success
+      expect(response.body).to eq controller.view_context.markdown(text)
+    end
+  end
+end


### PR DESCRIPTION
## やったこと
* JSのマークダウンパーサは意外とサーバーサイドと差分があるので、サーバーサイドでrenderした結果をプレビューとしてかえすようにする

## よくなったこと
* Windowsではemojiが白黒になってしまっていたが、カラー表示できるようになる
* 今までoctocatとかの文字はJS側ではプレビューで表示されなかったが、表示されるようになる

## 悪くなったこと
* 多少レスポンス遅く感じることがあるかも