### PR TITLE
POST /poems.json を定義

### DIFF
--- a/app/controllers/poems_controller.rb
+++ b/app/controllers/poems_controller.rb
@@ -1,6 +1,7 @@
 class PoemsController < ApplicationController
   before_filter :login_required
   before_action :set_poem, only: [:edit, :update]
+  skip_before_action :verify_authenticity_token, if: :json_request?
 
   def index
     @poems = Poem.where(user: current_user).order(created_at: :desc)
@@ -18,6 +19,7 @@ class PoemsController < ApplicationController
   def create
     @poem = PoemCreationService.create(current_user, poem_params, view_context: view_context)
     if @poem.valid?
+      render :show and return if json_request?
       redirect_to @poem
     else
       render :new
@@ -29,6 +31,7 @@ class PoemsController < ApplicationController
 
   def update
     if @poem.update(poem_params)
+      render :show and return if json_request?
       redirect_to @poem
     else
       render :edit


### PR DESCRIPTION
`/poems.json` のエンドポイントは、従来HTMLのみを返していたが、JSONリクエストに対応させないとアプリでは使いにくいため、処理を追加した。