### PR TITLE
FIX #99 次のポエムと前のポエムに遷移できるようにする

### DIFF
--- a/app/models/poem.rb
+++ b/app/models/poem.rb
@@ -21,4 +21,12 @@ class Poem < ActiveRecord::Base
   validates :description, presence: true
 
   has_many :read_poems, dependent: :destroy
+
+  def previous
+    Poem.where("created_at < ?", self.created_at).order("id DESC").first
+  end
+
+  def next
+    Poem.where("created_at > ?", self.created_at).order("id ASC").first
+  end
 end

--- a/app/models/read_poem.rb
+++ b/app/models/read_poem.rb
@@ -8,11 +8,6 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
-# Indexes
-#
-#  index_read_poems_on_poem_id  (poem_id)
-#  index_read_poems_on_user_id  (user_id)
-#
 
 class ReadPoem < ActiveRecord::Base
   belongs_to :user, required: true

--- a/app/views/poems/show.html.erb
+++ b/app/views/poems/show.html.erb
@@ -39,6 +39,24 @@
     <% end %>
   </div>
 </div>
+<div class="row poem-pager">
+  <div class="col-md-6 col-md-offset-3 next">
+    <nav>
+      <ul class="pager">
+        <% if @poem.next %>
+          <li class="previous">
+            <%= link_to @poem.next.title, @poem.next %>
+          </li>
+        <% end %>
+        <% if @poem.previous %>
+          <li class="next">
+            <%= link_to @poem.previous.title, @poem.previous %>
+          </li>
+        <% end %>
+      </ul>
+    </nav>
+  </div>
+</div>
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
     <ul class="nav nav-pills">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,7 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  nasulog: "nasulog"
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M"

--- a/spec/factories/poems.rb
+++ b/spec/factories/poems.rb
@@ -3,5 +3,17 @@ FactoryGirl.define do
     title 'hogehoge'
     description 'fugafuga'
     association :user, factory: :user
+
+    trait :now do
+      created_at Time.now
+    end
+
+    trait :one_hour_ago do
+      created_at 1.hours.ago
+    end
+
+    trait :tow_hour_ago do 
+      created_at 2.hours.ago
+    end
   end
 end

--- a/spec/models/poem_spec.rb
+++ b/spec/models/poem_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Poem, type: :model do
 
   describe '#next' do
     before do
-      @poem_current = create(:poem)
-      @poem_next = create(:poem)
+      @poem_current = create(:poem, :one_hour_ago)
+      @poem_next = create(:poem, :now)
     end
 
     subject {
@@ -47,8 +47,8 @@ RSpec.describe Poem, type: :model do
 
   describe '#previous' do
     before do
-      @poem_previous = create(:poem)
-      @poem_current = create(:poem)
+      @poem_previous = create(:poem, :one_hour_ago)
+      @poem_current = create(:poem, :now)
     end
 
     subject {

--- a/spec/models/poem_spec.rb
+++ b/spec/models/poem_spec.rb
@@ -30,4 +30,32 @@ RSpec.describe Poem, type: :model do
       it { is_expected.to eq false }
     end
   end
+
+  describe '#next' do
+    before do
+      @poem_current = create(:poem)
+      @poem_next = create(:poem)
+    end
+
+    subject {
+      @poem_current.next
+    }
+    context 'present next poem' do
+      it { is_expected.to eq @poem_next }
+    end
+  end
+
+  describe '#previous' do
+    before do
+      @poem_previous = create(:poem)
+      @poem_current = create(:poem)
+    end
+
+    subject {
+      @poem_current.previous
+    }
+    context 'present next poem' do
+      it { is_expected.to eq @poem_previous }
+    end
+  end
 end


### PR DESCRIPTION
ホームのポエムで次のポエムに遷移できるようにする。
自分のポエム一覧でも自分以外のポエムに遷移できてしまうが、ちょっと難しいのでいったん置いている。

![image](https://cloud.githubusercontent.com/assets/1456806/12530738/a1ec3a26-c22b-11e5-9518-e5fb05268c5b.png)
