### PR TITLE
FIX #134 タイトルが長いと次のポエムに遷移するバーのデザインが崩れるのを修正

### DIFF
--- a/app/assets/stylesheets/poem.scss
+++ b/app/assets/stylesheets/poem.scss
@@ -2,6 +2,30 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
+@mixin navWidth($width) {
+  .pager {
+    .previous{
+      a {
+        display: block;
+        width: $width;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
+
+    .next {
+      a{
+        display: block;
+        width: $width;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
+  }
+}
+
 .poem-area {
   min-height: 300px;
 }
@@ -31,6 +55,8 @@
   margin-bottom: 15px;
 }
 
+@include navWidth(250px);
+
 @media (max-width: 768px) {
   .repoem-link{
     margin-bottom: 0;
@@ -41,4 +67,6 @@
   .poem-form {
     margin: 15px;
   }
+
+  @include navWidth(150px);
 }


### PR DESCRIPTION
## PC版

![image](https://cloud.githubusercontent.com/assets/1456806/12648626/3895bb32-c61e-11e5-9fc5-e9e919b3e091.png)

## モバイル版

![image](https://cloud.githubusercontent.com/assets/1456806/12648637/448377e0-c61e-11e5-9fcc-4ea0262ffb3d.png)
