### PR TITLE
ポエムエリアの高さを変える

### DIFF
--- a/app/assets/stylesheets/poem.scss
+++ b/app/assets/stylesheets/poem.scss
@@ -26,10 +26,6 @@
   }
 }
 
-.poem-area {
-  min-height: 300px;
-}
-
 .emoji {
   vertical-align: middle;
   width: 20px;

--- a/app/controllers/read_poems_controller.rb
+++ b/app/controllers/read_poems_controller.rb
@@ -1,4 +1,8 @@
 class ReadPoemsController < ApplicationController
+  def index
+    @read_poems = Poem.joins(:read_poems).where("read_poems.user_id = ?", current_user.id).group(:id).order(created_at: :DESC)
+  end
+
   def create
     current_user.read_poems.create(poem_id: params[:poem_id])
     redirect_to :back

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,6 +15,7 @@
         <ul class="nav navbar-nav">
           <li><%= link_to "Home", home_index_path %></li>
           <li><%= link_to "My Poem", poems_path %></li>
+          <li><%= link_to "My Read Poem", read_poems_path %></li>
         </ul>
         <% end %>
         <p class="navbar-text navbar-right">

--- a/app/views/read_poems/index.html.erb
+++ b/app/views/read_poems/index.html.erb
@@ -1,0 +1,17 @@
+<div class="page-header">
+  <h1>読んだポエム一覧</h1>
+</div>
+<ul class="list-group container-fluid">
+  <% @read_poems.each do |poem| %>
+    <li class="list-group-item ">
+      <div class="row">
+        <div class="col-xs-8">
+          <%= link_to poem.title, poem %>
+        </div>
+        <div class="col-xs-4">
+          <%= l poem.created_at%>
+        </div>
+      </div>
+    </li>
+  <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   resources :poems, shallow: true do
     resources :read_poems, only: [:create, :destroy]
   end
+  resources :read_poems, only: [:index]
   resource :user, only: [:show, :edit, :update]
   root to: 'home#index'
 


### PR DESCRIPTION
ポエムエリアに`min-height`を設定していたけど。あると隙間が空いてしまって間抜けに見えるのでなくす。
これで短文でも違和感がなくなると思う。

![image](https://cloud.githubusercontent.com/assets/1456806/12693012/a5cbd10c-c743-11e5-9963-a0713d616e29.png)
