### PR TITLE
ポエムエリアの高さを調整

### DIFF
--- a/app/assets/stylesheets/poem.scss
+++ b/app/assets/stylesheets/poem.scss
@@ -26,10 +26,6 @@
   }
 }
 
-.poem-area {
-  min-height: 300px;
-}
-
 .emoji {
   vertical-align: middle;
   width: 20px;


### PR DESCRIPTION
ポエムエリアの高さを調整して短文でも隙間を空けないようにする。

![image](https://cloud.githubusercontent.com/assets/1456806/12693095/ec0fc56e-c744-11e5-9734-e8aa20245fba.png)
