### PR TITLE
fixes #156 load_more_pagenationを正しくロードできるようにrequireを追加

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,3 +1,5 @@
+require 'load_more_pagenation'
+
 class Api::ApplicationController < ApplicationController
   before_action :login_required
   skip_before_action :verify_authenticity_token

--- a/spec/controllers/api/poems_controller_spec.rb
+++ b/spec/controllers/api/poems_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Api::PoemsController, type: :controller do
+  context 'after login', login_as: :current_user do
+    let(:current_user) { create(:user) }
+    before do
+      current_user.poems.create(title:"スマホっていいね", description:"アプリのAPIを作るのは楽しい")
+    end
+
+    describe '/api/poems' do
+      subject { get :index, format: :json }
+      it { is_expected.to be_success }
+    end
+  end
+end


### PR DESCRIPTION
autoload_paths配下はrequireされたときには読まれるが、requireされないかぎり読まれないので、
`include LoadMorePagenation` している箇所で500エラーとなりAPIアクセスができていなかった。

→requireを追加します。