### PR TITLE
LoadMorePagenationのパラメータ指定がTimestamp型のカラムでうまく動かないことがあったので修正

### DIFF
--- a/lib/load_more_pagenation.rb
+++ b/lib/load_more_pagenation.rb
@@ -10,7 +10,7 @@ module LoadMorePagenation
     num = (num.present? && num.to_i>=0) ? num.to_i : 20
 
     data_all = self
-    data_all = data_all.where("#{column.to_s} < #{last_param}") if last_param.present?
+    data_all = data_all.where("#{column.to_s} < ?", last_param) if last_param.present?
     data_all = data_all.order("#{column.to_s} DESC").limit(num+1)
 
     if data_all.length > num


### PR DESCRIPTION
現状、 `load_more(:expired_at, param, 20)` のようにパラメータ指定すると、内部で
`"expired_at < #{param}"` という文字列を含んだSQLを発行しているが、
↑の文字列が期待通りに変数展開されず、SQLエラーとなることがあった。

`"expired_at < ?", param` のようにエスケープをしてRailsの仕組みにゆだねることで解決します。