### PR TITLE
Use /auth/google instead of /auth/google_oauth2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ nasum
   * とりあえず必須項目の Product name shown to users だけ入力すれば ok
 * Create client ID からクライアントIDを作る
   * Application type は web application を選択
-  * Authorized redirect URIs は `http://localhost:3000/auth/google_oauth2/callback` としておく (ドメインやポート番号はローカルの環境に合わせる)
+  * Authorized redirect URIs は `http://localhost:3000/auth/google/callback` としておく (ドメインやポート番号はローカルの環境に合わせる)
 * プロジェクトの Overview ページの Google APIs から、"Google+ API" を enable にする
 
 #### .env に環境変数を書いておく

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -19,7 +19,7 @@
         <% end %>
         <p class="navbar-text navbar-right">
           <% if current_user.blank? %>
-            <a href="/auth/google_oauth2">ログイン/新規登録</a>
+            <a href="/auth/google">ログイン/新規登録</a>
           <% else %>
             <%= link_to current_user.name, edit_user_path%> | <%= link_to 'ログアウト', logout_path %>
           <% end %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  options = { hd: ENV["RESTRICT_DOMAIN"] }
+  options = { hd: ENV["RESTRICT_DOMAIN"], name: 'google' }
   provider :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], options
 end
 OmniAuth.config.on_failure = Proc.new { |env|


### PR DESCRIPTION
## 何故

`rake routes`で、`/auth/google_oauth2`の部分は`:provider`と言っているので、そこにはOAuth providerの名前が入ると嬉しいなと思うんですが、**google**はomniauthのstrategyとして、OAuth1.0向けに[omniauth-google](https://github.com/Yesware/omniauth-google) が使っているので、[omniauth-google-oauth2](https://github.com/zquestz/omniauth-google-oauth2)となってしまい、いつもちょっとつらいなと思ってます。

```
GET    /auth/:provider/callback(.:format)       sessions#callback
POST   /auth/:provider/callback(.:format)       sessions#callback
```

## これはなに

`/auth/google_oauth2`より`/auth/google`の方がヨサソウに思えたのでちょいと設定してみました。

## 何が嬉しい

そんなに、スゴく嬉しすぎる！ってことはないかもしれないです。気になるってかんじなので、ゆるいPRとしてみて頂けると嬉しいです。
