### PR TITLE
libv8をupdate（OSX El Capitan）

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     json (1.8.3)
     less (2.6.0)
       commonjs (~> 0.2.7)
-    libv8 (3.16.14.13)
+    libv8 (3.16.14.15)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -380,5 +380,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 3.0)
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
こんにちは。

El capitanでよく遭遇する環境設定の問題で、libv8をupdateしました。
しなくてもEl capitanで動くのですかね？いまだ私は未解決なので、PRさせていただきました。

参考
http://kntmrkm.hatenablog.jp/entry/2016/02/20/150518

-- PS --
APIの勉強をreact_nativeとかでしてみたいと思ってたのでPRとか出していければと思います。