### PR TITLE
closes #131 login_requiredをapplication_controllerに定義する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,9 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  before_action :login_required
+
   helper_method :current_user
 
   private

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,4 @@
 class HomeController < ApplicationController
-
   skip_before_action :login_required
 
   def index

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,7 @@
 class HomeController < ApplicationController
+
+  skip_before_action :login_required
+
   def index
     @poems = Poem.all.order(id: :desc).includes(:user).page(params[:page])
     render "#{poems_path}/index" and return if current_user.present?

--- a/app/controllers/poems_controller.rb
+++ b/app/controllers/poems_controller.rb
@@ -1,5 +1,4 @@
 class PoemsController < ApplicationController
-  before_action :login_required
   before_action :set_poem, only: [:edit, :update, :destroy]
 
   def index

--- a/app/controllers/read_poems_controller.rb
+++ b/app/controllers/read_poems_controller.rb
@@ -1,5 +1,4 @@
 class ReadPoemsController < ApplicationController
-  before_action :login_required
 
   def index
     @read_poems = Poem.joins(:read_poems).where(read_poems: { user: current_user} ).uniq.order(created_at: :DESC).page(params[:page])

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,7 @@
 class SessionsController < ApplicationController
+
+  skip_before_action :login_required
+  
   def callback
     auth = request.env['omniauth.auth']
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,6 @@
 class SessionsController < ApplicationController
-
   skip_before_action :login_required
-  
+
   def callback
     auth = request.env['omniauth.auth']
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,5 @@
 # ユーザー情報を編集する
 class UsersController < ApplicationController
-  before_action :login_required
   before_action :set_user, only: [:show, :edit, :update]
 
   def show


### PR DESCRIPTION
login_requiredをapplication_controllerに定義する。
必要のないところは `skip_before_action` でスキップする。
